### PR TITLE
Fix  for `.github` repository URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
             HOSTNAME=${BASH_REMATCH[3]}
             DESTINATION_OWNER=${BASH_REMATCH[4]}
             DESTINATION_REPOSITORY=${BASH_REMATCH[5]}
-            if [[ $DESTINATION_REPOSITORY == *'.git'* ]] && [[ $DESTINATION_REPOSITORY != *'.github.io'* ]]; then
+            if [[ $DESTINATION_REPOSITORY == *'.git'* ]] && [[ $DESTINATION_REPOSITORY != *'.github.io'* ]] && [[ $DESTINATION_REPOSITORY != *'.github'* ]]; then
               DESTINATION_REPOSITORY=${DESTINATION_REPOSITORY//.git/ }
             fi
 


### PR DESCRIPTION
Closes: https://github.com/GuillaumeFalourd/copy-push-files/issues/1

### Description

URLs with `.github` weren't behaving as expected using the action.

The `v1` release will be override by this solution.
